### PR TITLE
feat(articulos): vistas de artículos estilizadas

### DIFF
--- a/src/articulos/adapters/forms.py
+++ b/src/articulos/adapters/forms.py
@@ -1,0 +1,63 @@
+"""
+Formularios de la app "articulos" (capa de adaptadores).
+
+Estos formularios ayudan a validar datos en las vistas, manteniendo el
+acoplamiento con Django dentro de la capa de infraestructura y
+permitiendo que el dominio permanezca libre de dependencias.
+"""
+from typing import List, Tuple
+
+from django import forms
+from django.apps import apps
+from django.forms import ModelForm
+
+
+class MapearArticuloForm(ModelForm):
+    """
+    Formulario para mapear un ArticuloSinRevisar hacia un Articulo.
+
+    - Modelo base: Articulo
+    - Campos: codigo_barras, descripcion
+    - Campo adicional: articulo_id (ChoiceField) para seleccionar un Articulo
+      existente o dejar vacío para crear uno nuevo.
+
+    Se utiliza en la vista `mapear_articulo` para validar datos antes de
+    ejecutar el caso de uso de mapeo.
+    """
+
+    articulo_id = forms.ChoiceField(
+        required=False,
+        choices=[],  # se completa dinámicamente en __init__
+        label="Artículo existente (opcional)",
+    )
+
+    class Meta:
+        model = apps.get_model("articulos", "Articulo")
+        fields = ["codigo_barras", "descripcion"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        Articulo = apps.get_model("articulos", "Articulo")
+        # Poblar choices con artículos existentes en la base de negocio
+        opciones: List[Tuple[str, str]] = [("", "Crear nuevo")]
+        for art in Articulo.objects.using("negocio_db").all()[:500]:
+            etiqueta = f"{getattr(art, 'codigo_barras', '')} - {getattr(art, 'nombre', getattr(art, 'descripcion', ''))}"
+            opciones.append((str(art.id), etiqueta))
+        self.fields["articulo_id"].choices = opciones
+
+        # Estilos Tailwind para widgets, alineados con core_auth
+        base_input = {
+            "class": "appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
+        }
+        self.fields["codigo_barras"].widget.attrs.update({
+            **base_input,
+            "placeholder": "Código de barras",
+        })
+        self.fields["descripcion"].widget.attrs.update({
+            **base_input,
+            "placeholder": "Descripción para publicación",
+            "rows": 3,
+        })
+        self.fields["articulo_id"].widget.attrs.update({
+            "class": "block w-full px-3 py-2 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm",
+        })

--- a/src/articulos/adapters/views.py
+++ b/src/articulos/adapters/views.py
@@ -1,1 +1,146 @@
-# Archivo de vistas del adaptador
+"""
+Vistas de la app "articulos" (capa de adaptadores) usando arquitectura hexagonal.
+
+Estas vistas delegan la lógica de negocio a casos de uso del dominio para
+mantener el desacople entre Django y la lógica pura de Python.
+"""
+
+from typing import Any, Dict, List
+
+from django.apps import apps
+from django.shortcuts import redirect, render
+from django.views.generic import ListView
+
+from ..domain.use_cases import BuscarArticuloUseCase, MapearArticuloUseCase
+from .repository import BusquedaRepository, MapeoRepository
+from .forms import MapearArticuloForm
+
+
+class BuscarArticuloView(ListView):
+    """
+    Vista de búsqueda que utiliza el caso de uso BuscarArticuloUseCase.
+
+    - template_name: articulos/buscar_articulos.html
+    - context_object_name: "resultados"
+
+    Los resultados pueden incluir entradas provenientes de:
+      - PrecioDeLista
+      - ArticuloSinRevisar
+      - ArticuloProveedor
+    """
+
+    template_name = "articulos/buscar_articulos.html"
+    context_object_name = "resultados"
+
+    def get_queryset(self) -> List[Dict[str, Any]]:  # type: ignore[override]
+        query = self.request.GET.get("q", "")
+        use_case = BuscarArticuloUseCase(BusquedaRepository())
+        return use_case.execute(query=query)
+
+    def get_context_data(self, **kwargs):  # type: ignore[override]
+        context = super().get_context_data(**kwargs)
+        context["query"] = self.request.GET.get("q", "")
+        return context
+
+
+def mapear_articulo(request, pendiente_id: int):
+    """
+    Vista de función para mapear un ArticuloSinRevisar hacia un Articulo existente.
+
+    Flujo:
+    - GET: muestra una página con los datos del pendiente y una descripción sugerida.
+    - POST: procesa el formulario (p.ej. codigo_barras, descripcion); crea o actualiza
+      un Articulo y ejecuta el mapeo mediante MapearArticuloUseCase. Finalmente
+      redirige a la búsqueda de artículos.
+    """
+
+    Articulo = apps.get_model("articulos", "Articulo")
+    ArticuloSinRevisar = apps.get_model("articulos", "ArticuloSinRevisar")
+
+    # Siempre leemos el pendiente desde la base de negocio
+    pendiente = (
+        ArticuloSinRevisar.objects.using("negocio_db").select_related("proveedor", "descuento").get(pk=pendiente_id)
+    )
+
+    if request.method == "POST":
+        # Integración con forms: validar datos del POST con MapearArticuloForm
+        form = MapearArticuloForm(request.POST)
+        if form.is_valid():
+            codigo_barras = (form.cleaned_data.get("codigo_barras") or "").strip()
+            descripcion = (form.cleaned_data.get("descripcion") or "").strip() or pendiente.descripcion_proveedor
+            articulo_id = (form.cleaned_data.get("articulo_id") or "").strip()
+
+            # Usar artículo existente si se seleccionó
+            if articulo_id:
+                art = Articulo.objects.using("negocio_db").get(pk=articulo_id)
+            else:
+                # Crear o actualizar Articulo en base de negocio
+                if codigo_barras:
+                    art, _created = Articulo.objects.using("negocio_db").get_or_create(
+                        codigo_barras=codigo_barras,
+                        defaults={"descripcion": descripcion},
+                    )
+                    # Si ya existía, actualizar descripción si viene en formulario
+                    if not _created and descripcion:
+                        if getattr(art, "descripcion", None) != descripcion:
+                            art.descripcion = descripcion
+                            art.save(using="negocio_db")
+                else:
+                    # Si no hay código de barras, crear un Articulo genérico con descripción
+                    art = Articulo.objects.using("negocio_db").create(descripcion=descripcion)
+
+            # Ejecutar caso de uso de mapeo (adaptador MapeoRepository).
+            # Nota: el caso de uso aún invoca el puerto con 'usuario_id', se adapta localmente.
+            class _MapeoRepoAdapter:
+                def mapear_articulo(self, *, articulo_s_revisar_id, articulo_id, usuario_id=None):  # type: ignore[override]
+                    repo = MapeoRepository()
+                    return repo.mapear_articulo(
+                        articulo_s_revisar_id=articulo_s_revisar_id,
+                        articulo_id=articulo_id,
+                    )
+
+            use_case = MapearArticuloUseCase(_MapeoRepoAdapter())
+            use_case.execute(articulo_s_revisar_id=pendiente.id, articulo_id=art.id, usuario_id=None)
+
+            # Volver a la búsqueda
+            return redirect("articulos:buscar_articulos")
+        else:
+            # Form inválido: continuar para renderizar errores
+            pass
+
+        # Ejecutar caso de uso de mapeo (adaptador MapeoRepository).
+        # Nota: el caso de uso aún invoca el puerto con 'usuario_id',
+        # por lo que definimos un pequeño adaptador que acepta ese argumento
+        # y lo ignora delegando al repositorio real.
+
+        class _MapeoRepoAdapter:
+            def mapear_articulo(self, *, articulo_s_revisar_id, articulo_id, usuario_id=None):  # type: ignore[override]
+                repo = MapeoRepository()
+                return repo.mapear_articulo(
+                    articulo_s_revisar_id=articulo_s_revisar_id,
+                    articulo_id=articulo_id,
+                )
+
+        use_case = MapearArticuloUseCase(_MapeoRepoAdapter())
+        use_case.execute(articulo_s_revisar_id=pendiente.id, articulo_id=art.id, usuario_id=None)  # usuario_id no usado
+
+        # Volver a la búsqueda
+        return redirect("articulos:buscar_articulos")
+
+    # GET: mostrar plantilla con datos del pendiente y sugerencia de descripción
+    # GET: inicializar formulario con descripción sugerida; en POST, reutilizar form si existe
+    if request.method == "GET":
+        form = MapearArticuloForm(initial={"descripcion": pendiente.descripcion_proveedor})
+    else:
+        form = locals().get("form") or MapearArticuloForm()
+
+    contexto = {
+        "pendiente": pendiente,
+        "descripcion_sugerida": pendiente.descripcion_proveedor,
+        "codigo_sugerido": f"{pendiente.codigo_proveedor}/{pendiente.proveedor.abreviatura}",
+        # Proveer el modelo para que la plantilla pueda iterar Articulo.objects.all
+        "Articulo": apps.get_model("articulos", "Articulo"),
+        # Proveer el formulario para renderizado/errores
+        "form": form,
+    }
+    return render(request, "articulos/mapear_articulo.html", contexto)

--- a/src/articulos/urls.py
+++ b/src/articulos/urls.py
@@ -1,0 +1,33 @@
+"""
+URLs de la app "articulos".
+
+Incluir en core_config/urls.py con:
+    path("articulos/", include("articulos.urls"))
+
+Los nombres de las rutas se usan para reverse, por ejemplo:
+    reverse('articulos:buscar_articulos')
+    reverse('articulos:mapear_articulo', kwargs={'pendiente_id': 123})
+"""
+from django.urls import path
+from articulos.adapters.views import (
+    BuscarArticuloView,
+    mapear_articulo,  # vista de función para el mapeo
+)
+
+# Namespace de la app para usar con reverse('articulos:...')
+app_name = "articulos"
+
+urlpatterns = [
+    # Búsqueda de artículos (vista basada en clase)
+    # Uso: reverse('articulos:buscar_articulos') -> "/articulos/buscar/"
+    path("buscar/", BuscarArticuloView.as_view(), name="buscar_articulos"),
+
+    # Mapeo de ArticuloSinRevisar -> Articulo (vista de función)
+    # Nota: el convertidor correcto en Django es <int:pendiente_id>
+    # Uso: reverse('articulos:mapear_articulo', kwargs={'pendiente_id': 1}) -> "/articulos/mapear/1/"
+    # Integración con forms: la vista `mapear_articulo` utiliza `MapearArticuloForm`
+    # para validar datos del POST (codigo_barras, descripcion y articulo_id) y
+    # renderizar errores en GET/POST. La URL permanece igual; solo cambia la
+    # lógica interna de validación en la vista.
+    path("mapear/<int:pendiente_id>/", mapear_articulo, name="mapear_articulo"),
+]

--- a/src/core_config/urls.py
+++ b/src/core_config/urls.py
@@ -27,5 +27,7 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('auth/', include(('core_auth.adapters.urls', 'core_auth'), namespace='core_auth')),
     path('dashboard/', include('core_app.adapters.urls', namespace='core_app')),  # Para el dashboard genérico
+    # URLs de la app articulos (vistas y formularios de búsqueda/mapeo)
+    path('articulos/', include('articulos.urls')),
 ]
 

--- a/src/templates/articulos/buscar_articulos.html
+++ b/src/templates/articulos/buscar_articulos.html
@@ -1,0 +1,73 @@
+{% extends 'base.html' %}
+{# Template de búsqueda de artículos. Hereda de base.html y define el bloque 'content'. #}
+
+{% block content %}
+  <div class="max-w-5xl mx-auto p-4 sm:p-6 lg:p-8">
+    <div class="bg-white shadow rounded-lg p-6">
+      <div class="mb-6">
+        <h1 class="text-2xl font-semibold text-gray-900">Buscar artículos</h1>
+        <p class="mt-1 text-sm text-gray-500">Buscá por código o por código/abreviatura (p.ej., 37 o 37/Vj).</p>
+      </div>
+
+      {# Formulario GET para búsqueda por código o código/abreviatura (p.ej., 37 o 37/Vj) #}
+      <form method="GET" class="flex gap-3 items-center">
+        <input
+          type="text"
+          name="q"
+          value="{{ query }}"
+          placeholder="Buscar por código (e.g., 37 o 37/Vj)"
+          class="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+        >
+        <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+          <i class="fas fa-search mr-2"></i>Buscar
+        </button>
+      </form>
+
+      {# Lista de resultados: cada resultado incluye código, descripción, proveedor y precio #}
+      <div class="mt-6">
+        {% if resultados %}
+          <ul role="list" class="divide-y divide-gray-200">
+            {% for resultado in resultados %}
+              <li class="py-4 flex items-start justify-between">
+                <div>
+                  <div class="flex items-center gap-2">
+                    <span class="font-medium text-gray-900">{{ resultado.codigo }}</span>
+                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">{{ resultado.proveedor }}</span>
+                  </div>
+                  <p class="mt-1 text-sm text-gray-600">{{ resultado.descripcion }}</p>
+                  <p class="mt-1 text-sm text-gray-900">${{ resultado.precio }}</p>
+                </div>
+                <div class="ml-4">
+                  {# Mostrar enlace para mapear solo si es un ArticuloSinRevisar. #}
+                  {% if resultado.tipo == 'articulo_sin_revisar' or resultado.tipo == 'sin_revisar' %}
+                    <a href="{% url 'articulos:mapear_articulo' resultado.id %}"
+                       class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-amber-600 hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500">
+                      <i class="fas fa-link mr-2"></i>Mapear
+                    </a>
+                  {% endif %}
+                </div>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <div class="mt-4 rounded-md bg-blue-50 p-4">
+            <div class="flex">
+              <div class="flex-shrink-0">
+                <i class="fas fa-info-circle text-blue-400"></i>
+              </div>
+              <div class="ml-3">
+                <p class="text-sm text-blue-800">
+                  {% if query %}
+                    No hay resultados para "{{ query }}".
+                  {% else %}
+                    Ingresá un término de búsqueda para comenzar.
+                  {% endif %}
+                </p>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/src/templates/articulos/mapear_articulo.html
+++ b/src/templates/articulos/mapear_articulo.html
@@ -1,0 +1,88 @@
+{% extends 'base.html' %}
+{# Template de mapeo de ArticuloSinRevisar -> Articulo. Hereda de base.html y define el bloque 'content'. #}
+
+{% block content %}
+  <div class="max-w-3xl mx-auto p-4 sm:p-6 lg:p-8">
+    <div class="bg-white shadow rounded-lg p-6">
+      <div class="mb-6">
+        <h1 class="text-2xl font-semibold text-gray-900">Mapear artículo pendiente</h1>
+        <p class="mt-2 text-sm text-gray-600">
+          <span class="font-medium">Proveedor:</span>
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">{{ pendiente.proveedor }}</span>
+        </p>
+        <p class="mt-1 text-sm text-gray-600">
+          <span class="font-medium">Descripción del proveedor:</span> {{ pendiente.descripcion_proveedor }}
+        </p>
+        <p class="mt-1 text-xs text-gray-500">
+          <span class="font-medium">Código sugerido:</span> {{ codigo_sugerido }}
+        </p>
+      </div>
+
+      {# Integración con forms: usar MapearArticuloForm para validar y renderizar campos #}
+      <form method="POST" class="space-y-6">
+        {% csrf_token %}
+
+        {% if form.non_field_errors %}
+          <div class="rounded-md bg-red-50 p-4">
+            <div class="flex">
+              <div class="flex-shrink-0">
+                <i class="fas fa-exclamation-circle h-5 w-5 text-red-400"></i>
+              </div>
+              <div class="ml-3">
+                {% for error in form.non_field_errors %}
+                  <p class="text-sm font-medium text-red-800">{{ error }}</p>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+        {% endif %}
+
+        <div>
+          <label for="{{ form.codigo_barras.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
+            Código de barras
+          </label>
+          {{ form.codigo_barras }}
+          {% if form.codigo_barras.errors %}
+            {% for error in form.codigo_barras.errors %}
+              <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+            {% endfor %}
+          {% endif %}
+        </div>
+
+        <div>
+          <label for="{{ form.descripcion.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
+            Descripción para publicación
+          </label>
+          {{ form.descripcion }}
+          <p class="mt-1 text-xs text-gray-500">Sugerida: {{ descripcion_sugerida }}</p>
+          {% if form.descripcion.errors %}
+            {% for error in form.descripcion.errors %}
+              <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+            {% endfor %}
+          {% endif %}
+        </div>
+
+        <div>
+          <label for="{{ form.articulo_id.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
+            Artículo existente (opcional)
+          </label>
+          {{ form.articulo_id }}
+          {% if form.articulo_id.errors %}
+            {% for error in form.articulo_id.errors %}
+              <p class="mt-1 text-sm text-red-600">{{ error }}</p>
+            {% endfor %}
+          {% endif %}
+        </div>
+
+        <div class="flex items-center justify-between">
+          <a href="{% url 'articulos:buscar_articulos' %}" class="text-sm text-gray-600 hover:text-gray-800">
+            <i class="fas fa-arrow-left mr-1"></i> Volver a búsqueda
+          </a>
+          <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            <i class="fas fa-paper-plane mr-2"></i>Mapear
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -64,6 +64,11 @@
                         <a href="{% url 'home' %}" class="border-indigo-500 text-gray-900 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium">
                             Inicio
                         </a>
+                        <!-- Link a Artículos (búsqueda) -->
+                        <a href="{% url 'articulos:buscar_articulos' %}" class="text-gray-500 hover:text-gray-700 inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium">
+                            <i class="fas fa-boxes-stacked mr-1"></i>
+                            Artículos
+                        </a>
                     </div>
                 </div>
                 <div class="hidden sm:ml-6 sm:flex sm:items-center">
@@ -115,6 +120,12 @@
             <div class="pt-2 pb-3 space-y-1">
                 <a href="{% url 'home' %}" class="bg-indigo-50 border-indigo-500 text-indigo-700 block pl-3 pr-4 py-2 border-l-4 text-base font-medium">
                     Inicio
+                </a>
+                <!-- Link móvil a Artículos (búsqueda) -->
+                <a href="{% url 'articulos:buscar_articulos' %}" class="text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800 block pl-3 pr-4 py-2 border-l-4 text-base font-medium border-transparent">
+                    <span class="inline-flex items-center">
+                        <i class="fas fa-boxes-stacked mr-2"></i>Artículos
+                    </span>
                 </a>
                 {% if user.is_authenticated %}
                     {% if user.is_staff %}


### PR DESCRIPTION
Este PR implementa el estilado de las vistas de artículos y mejora la UX conforme a los formularios de core_auth.\n\nCambios principales:\n- buscar_articulos.html: card con sombra, form de búsqueda estilizado, lista de resultados con badges y botón ‘Mapear’, estado vacío informativo.\n- mapear_articulo.html: reemplazo de inputs crudos por render del MapearArticuloForm con labels y errores, card y acciones (volver/mapear).\n- MapearArticuloForm: clases Tailwind en widgets (inputs/select/textarea), placeholders, y límite razonable de opciones en el select.\n\nNotas:\n- Se mantiene la arquitectura hexagonal (vista delega en use cases/repos); sólo se tocan templates y form adapter.\n- Navegación desde el navbar hacia articulos:buscar_articulos ya disponible.\n- Pendiente QA visual y funcional end-to-end en entorno local.