### PR TITLE
ci: automate deploy migrations + standard-version releases

### DIFF
--- a/.github/workflows/backmerge-pre-release.yml
+++ b/.github/workflows/backmerge-pre-release.yml
@@ -1,9 +1,9 @@
-name: Backmerge main -> pre-release
+name: Backmerge release -> pre-release
 
 on:
   push:
     branches:
-      - main
+      - release
 
 permissions:
   contents: write
@@ -26,14 +26,14 @@ jobs:
         run: |
           git fetch origin +refs/heads/*:refs/remotes/origin/*
 
-      - name: Merge main -> pre-release
+      - name: Merge release -> pre-release
         shell: bash
         run: |
           set -e
           # Ensure we have both branches locally
           git checkout -B pre-release origin/pre-release
           # Try the merge (fast-forward or merge commit)
-          if git merge --no-ff origin/main -m "chore: back-merge main into pre-release (run $GITHUB_RUN_ID)"; then
+          if git merge --no-ff origin/release -m "chore: back-merge release into pre-release (run $GITHUB_RUN_ID)"; then
             git push origin pre-release
             echo "Back-merge completed and pushed."
           else

--- a/.github/workflows/build-pre-release.yml
+++ b/.github/workflows/build-pre-release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-build-push.yml@pre-release
+    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-build-push.yml@main
     secrets: inherit
     with:
       image_repo: DarkyDieLJob/gestionferreteria

--- a/.github/workflows/build-pre-release.yml
+++ b/.github/workflows/build-pre-release.yml
@@ -11,12 +11,12 @@ permissions:
 
 jobs:
   build:
-    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-build-push.yml@main
+    uses: ./.github/workflows/reusable-build-push.yml
     secrets: inherit
     with:
-      image_repo: DarkyDieLJob/gestionferreteria
+      image_repo: darkydieljob/gestionferreteria
       # Publica para staging
-      tags: staging-latest,sha-${{ github.sha }}
+      tags: ghcr.io/darkydieljob/gestionferreteria:staging-latest,ghcr.io/darkydieljob/gestionferreteria:sha-${{ github.sha }}
       platforms: linux/amd64,linux/arm64
       context: .
       dockerfile: Dockerfile

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,8 +3,8 @@ name: Build & Push (release/tag)
 on:
   push:
     branches: [release]       # Se ejecuta al pushear/mergear a release
-    tags:
-      - 'v*'                  # También al crear tags vX.Y.Z
+    # tags:
+    #   - 'v*'                  # Manejado por release-cicd.yml (build + deploy) para evitar doble ejecución
   workflow_dispatch: {}       # Permite ejecución manual
 
 permissions:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,12 +13,12 @@ permissions:
 
 jobs:
   build:
-    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-build-push.yml@pre-release
+    uses: ./.github/workflows/reusable-build-push.yml
     secrets: inherit
     with:
-      image_repo: DarkyDieLJob/gestionferreteria
+      image_repo: darkydieljob/gestionferreteria
       # Si el evento es tag vX.Y.Z, se usa ese nombre como tag de imagen
-      tags: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+      tags: ${{ startsWith(github.ref, 'refs/tags/v') && format('ghcr.io/darkydieljob/gestionferreteria:{0}', github.ref_name) || format('ghcr.io/darkydieljob/gestionferreteria:sha-{0}', github.sha) }}
       platforms: linux/amd64,linux/arm64
       context: .
       dockerfile: Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - release
       - develop
       - pre-release
       - 'feature/**'
@@ -11,7 +11,7 @@ on:
       - 'v*'
   pull_request:
     branches:
-      - main
+      - release
       - develop
       - pre-release
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,15 +15,36 @@ permissions:
 
 jobs:
   deploy:
-    environment: production   # Configurá aprobación manual desde Settings > Environments
-    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-pull-deploy.yml@pre-release
-    secrets: inherit
-    with:
-      runner_label: "prod"                  # Ajusta si tu runner usa otro label
-      image_repo: DarkyDieLJob/gestionferreteria
-      image_tag: ${{ inputs.version }}      # Producción SIEMPRE pinneada a vX.Y.Z
-      compose_files: docker-compose.yml
-      deny_latest: true
-      base_url: http://127.0.0.1:8001
-      smoke_url: "/"
+    environment:
+      name: production   # Configurá aprobación manual desde Settings > Environments
+    runs-on: [self-hosted, prod]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker login to GHCR
+        env:
+          CR_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Set image environment
+        run: |
+          echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
+          echo "IMAGE_REPO=DarkyDieLJob/gestionferreteria" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{ inputs.version }}" >> $GITHUB_ENV
+
+      - name: Pull images
+        run: docker compose pull
+
+      - name: Compose up
+        run: docker compose up -d --remove-orphans
+
+      - name: Smoke check
+        run: |
+          set -euo pipefail
+          end=$((SECONDS+120))
+          until curl -fsS http://127.0.0.1:8001/ >/dev/null; do
+            [ $SECONDS -ge $end ] && { echo "Smoke failed"; docker compose logs --no-color app || true; exit 1; }
+            sleep 3
+          done
       # Cuando quieras automatizar, podés crear un flujo que se dispare con tags v* o rama release.

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -33,10 +33,14 @@ jobs:
           echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
           echo "IMAGE_TAG=${{ inputs.version }}" >> $GITHUB_ENV
 
-      - name: Pull images
+      - name: Pull images (with profiles)
+        env:
+          COMPOSE_PROFILES: db,broker,web
         run: docker compose pull
 
-      - name: Compose up
+      - name: Compose up (with profiles)
+        env:
+          COMPOSE_PROFILES: db,broker,web
         run: docker compose up -d --remove-orphans
 
       - name: Smoke check

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set image environment
         run: |
           echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
-          echo "IMAGE_REPO=DarkyDieLJob/gestionferreteria" >> $GITHUB_ENV
+          echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
           echo "IMAGE_TAG=${{ inputs.version }}" >> $GITHUB_ENV
 
       - name: Pull images

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,10 +30,14 @@ jobs:
           echo "IMAGE_REPO=DarkyDieLJob/gestionferreteria" >> $GITHUB_ENV
           echo "IMAGE_TAG=staging-latest" >> $GITHUB_ENV
 
-      - name: Pull images
+      - name: Pull images (with profiles)
+        env:
+          COMPOSE_PROFILES: db,broker,web
         run: docker compose pull
 
-      - name: Compose up
+      - name: Compose up (with profiles)
+        env:
+          COMPOSE_PROFILES: db,broker,web
         run: docker compose up -d --remove-orphans
 
       - name: Smoke check

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,10 +30,15 @@ jobs:
           echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
           echo "IMAGE_TAG=staging-latest" >> $GITHUB_ENV
 
-      - name: Pull images (with profiles)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        run: docker compose pull
+      - name: Ensure app image exists (pull or build)
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMG="${IMAGE_REGISTRY}/${IMAGE_REPO}:${IMAGE_TAG}"
+          if ! docker pull "$IMG"; then
+            echo "App image $IMG not found in registry. Building locally..."
+            docker build --target runtime -t "$IMG" -f Dockerfile .
+          fi
 
       - name: Compose up (with profiles)
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set image environment
         run: |
           echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
-          echo "IMAGE_REPO=DarkyDieLJob/gestionferreteria" >> $GITHUB_ENV
+          echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
           echo "IMAGE_TAG=staging-latest" >> $GITHUB_ENV
 
       - name: Pull images (with profiles)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,15 +12,36 @@ permissions:
 
 jobs:
   deploy:
-    environment: staging
-    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-pull-deploy.yml@pre-release
-    secrets: inherit
-    with:
-      runner_label: "stage"                 # Ajusta si tu runner usa otro label
-      image_repo: DarkyDieLJob/gestionferreteria
-      image_tag: staging-latest            # Staging usa alias mutable
-      compose_files: docker-compose.yml
-      deny_latest: true                    # Bloquea latest en ambientes que lo impiden
-      base_url: http://127.0.0.1:8001      # Tu app expone 8001
-      smoke_url: "/"
+    environment:
+      name: staging
+    runs-on: [self-hosted, stage]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker login to GHCR
+        env:
+          CR_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Set image environment
+        run: |
+          echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
+          echo "IMAGE_REPO=DarkyDieLJob/gestionferreteria" >> $GITHUB_ENV
+          echo "IMAGE_TAG=staging-latest" >> $GITHUB_ENV
+
+      - name: Pull images
+        run: docker compose pull
+
+      - name: Compose up
+        run: docker compose up -d --remove-orphans
+
+      - name: Smoke check
+        run: |
+          set -euo pipefail
+          end=$((SECONDS+120))
+          until curl -fsS http://127.0.0.1:8001/ >/dev/null; do
+            [ $SECONDS -ge $end ] && { echo "Smoke failed"; docker compose logs --no-color app || true; exit 1; }
+            sleep 3
+          done
       # Para despliegue real automático, agregá el trigger por rama y ejecutá este flujo.

--- a/.github/workflows/deploy.example.yml
+++ b/.github/workflows/deploy.example.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-deploy.yml@main
+    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-deploy.yml@release
     with:
       tag_version: ${{ github.ref_name }}
       profiles: 'db,broker,worker'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy (child consumer)
 on:
   push:
     tags:
-      - "test-*"
+      - "test-deploy-*"
       # - "v*"  # opcional: habilitar releases reales
   workflow_dispatch: {}
 

--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -1,17 +1,16 @@
-name: Release Back-Merge
+name: Legacy Release Back-Merge (disabled)
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   backmerge-develop:
-    name: Back-merge main -> develop on tag
+    name: Back-merge release -> develop on tag (disabled)
     runs-on: ubuntu-latest
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,15 +26,15 @@ jobs:
         run: |
           git fetch origin +refs/heads/*:refs/remotes/origin/* --prune
 
-      - name: Merge main into develop
+      - name: Merge release into develop
         shell: bash
         run: |
           set -euxo pipefail
           # Ensure we have the latest
           git checkout develop
           git reset --hard origin/develop
-          # Merge origin/main into develop
-          git merge --no-ff origin/main -m "chore: back-merge main into develop after ${{ github.ref_name }}"
+          # Merge origin/release into develop
+          git merge --no-ff origin/release -m "chore: back-merge release into develop after ${{ github.ref_name }}"
           # If nothing to commit, skip push
           if git diff --quiet origin/develop...HEAD; then
             echo "No changes to push"

--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -27,12 +27,131 @@ jobs:
       context: .
       dockerfile: Dockerfile
 
-  deploy_prod:
-    name: Deploy (production)
+  deploy_staging:
+    name: Deploy (staging)
     needs: [build]
     environment:
+      name: staging
+    runs-on: [self-hosted, stage, docker]
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify Docker availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v docker >/dev/null 2>&1 || { echo "docker not found on runner (PATH). Install Docker and ensure runner user can execute it."; exit 1; }
+          docker --version
+          docker compose version || true
+
+      - name: Resolve IMAGE_TAG
+        id: resolve_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_INPUT="${{ inputs.version }}"
+          REF_NAME="${{ github.ref_name }}"
+          if [ -n "${TAG_INPUT}" ]; then
+            TAG="${TAG_INPUT}"
+          else
+            TAG="${REF_NAME}"
+          fi
+          if ! echo "$TAG" | grep -Eq '^(v|test-pipeline-)'; then
+            echo "Refusing to deploy: resolved tag '$TAG' does not look like a supported release tag (v* or test-pipeline-*). Provide inputs.version or run on a matching tag." >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Docker login to GHCR
+        env:
+          CR_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Set image environment
+        run: |
+          echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
+          echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{ steps.resolve_tag.outputs.tag }}" >> $GITHUB_ENV
+
+      - name: Pull images (with profiles)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        run: docker compose pull
+
+      - name: Compose diagnostics (before up)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        shell: bash
+        run: |
+          pwd
+          ls -la
+          ls -la docker-compose.yml docker-compose.yaml compose.yml compose.yaml || true
+          echo "COMPOSE_PROFILES=$COMPOSE_PROFILES"
+          env | sort | grep -E 'COMPOSE|IMAGE_|POSTGRES|DJANGO|ENV' || true
+          docker compose version || true
+          docker compose config --services || true
+          docker compose config --profiles || true
+
+      - name: Compose up (with profiles)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        run: docker compose --profile db --profile broker --profile web up -d --remove-orphans
+
+      - name: Smoke check
+        run: |
+          set -euo pipefail
+          end=$((SECONDS+120))
+          until curl -fsS http://127.0.0.1:8001/ >/dev/null; do
+            [ $SECONDS -ge $end ] && { echo "Smoke failed"; docker compose logs --no-color app || true; exit 1; }
+            sleep 3
+          done
+
+  backmerge_release_to_develop:
+    name: Back-merge release -> develop
+    needs: [deploy_staging]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch all branches
+        run: |
+          git fetch origin +refs/heads/*:refs/remotes/origin/* --prune
+
+      - name: Merge release into develop
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git checkout develop
+          git reset --hard origin/develop
+          git merge --no-ff origin/release -m "chore: back-merge release into develop after ${{ github.ref_name }}"
+          if git diff --quiet origin/develop...HEAD; then
+            echo "No changes to push"
+          else
+            git push origin HEAD:develop
+          fi
+
+  deploy_prod:
+    name: Deploy (production)
+    needs: [backmerge_release_to_develop]
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment:
       name: production
-    runs-on: [self-hosted, prod]
+    runs-on: [self-hosted, prod, docker]
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -1,26 +1,62 @@
-name: Deploy (production)
+name: Release (build + deploy prod)
 
 on:
-  # Dejamos solo manual y con gate por environment si configurás uno llamado 'production'
+  push:
+    tags:
+      - 'v*'
+      - 'test-pipeline-*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Tag de imagen (vX.Y.Z)'
-        required: true
+        description: 'Tag de imagen (vX.Y.Z o test-pipeline-YYYYMMDD-N). Si se deja vacío, se usa github.ref_name (solo válido si el workflow corre sobre un tag).'
+        required: false
         type: string
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 jobs:
-  deploy:
+  build:
+    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-build-push.yml@pre-release
+    secrets: inherit
+    with:
+      image_repo: DarkyDieLJob/gestionferreteria
+      tags: ${{ inputs.version != '' && inputs.version || github.ref_name }}
+      platforms: linux/amd64,linux/arm64
+      context: .
+      dockerfile: Dockerfile
+
+  deploy_prod:
+    name: Deploy (production)
+    needs: [build]
     environment:
-      name: production   # Configurá aprobación manual desde Settings > Environments
+      name: production
     runs-on: [self-hosted, prod]
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve IMAGE_TAG
+        id: resolve_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_INPUT="${{ inputs.version }}"
+          REF_NAME="${{ github.ref_name }}"
+          if [ -n "${TAG_INPUT}" ]; then
+            TAG="${TAG_INPUT}"
+          else
+            TAG="${REF_NAME}"
+          fi
+          if ! echo "$TAG" | grep -Eq '^(v|test-pipeline-)'; then
+            echo "Refusing to deploy: resolved tag '$TAG' does not look like a supported release tag (v* or test-pipeline-*). Provide inputs.version or run on a matching tag." >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Docker login to GHCR
         env:
@@ -31,7 +67,7 @@ jobs:
         run: |
           echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
           echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
-          echo "IMAGE_TAG=${{ inputs.version }}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{ steps.resolve_tag.outputs.tag }}" >> $GITHUB_ENV
 
       - name: Pull images (with profiles)
         env:
@@ -65,4 +101,3 @@ jobs:
             [ $SECONDS -ge $end ] && { echo "Smoke failed"; docker compose logs --no-color app || true; exit 1; }
             sleep 3
           done
-      # Cuando quieras automatizar, podés crear un flujo que se dispare con tags v* o rama release.

--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify Docker availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v docker >/dev/null 2>&1 || { echo "docker not found on runner (PATH). Install Docker and ensure runner user can execute it."; exit 1; }
+          docker --version
+          docker compose version || true
+
       - name: Resolve IMAGE_TAG
         id: resolve_tag
         shell: bash

--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -96,6 +96,16 @@ jobs:
           docker compose config --services || true
           docker compose config --profiles || true
 
+      - name: Compose up deps (db + broker)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        run: docker compose --profile db --profile broker up -d db redis
+
+      - name: Run migrations (in-situ)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        run: docker compose run --rm app python src/manage.py migrate --run-syncdb --noinput
+
       - name: Compose up (with profiles)
         env:
           COMPOSE_PROFILES: db,broker,web
@@ -214,6 +224,16 @@ jobs:
           docker compose version || true
           docker compose config --services || true
           docker compose config --profiles || true
+
+      - name: Compose up deps (db + broker)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        run: docker compose --profile db --profile broker up -d db redis
+
+      - name: Run migrations (in-situ)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        run: docker compose run --rm app python src/manage.py migrate --run-syncdb --noinput
 
       - name: Compose up (with profiles)
         env:

--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -18,11 +18,11 @@ permissions:
 
 jobs:
   build:
-    uses: DarkyDieLJob/DjangoProyects/.github/workflows/reusable-build-push.yml@pre-release
+    uses: ./.github/workflows/reusable-build-push.yml
     secrets: inherit
     with:
-      image_repo: DarkyDieLJob/gestionferreteria
-      tags: ${{ inputs.version != '' && inputs.version || github.ref_name }}
+      image_repo: darkydieljob/gestionferreteria
+      tags: ${{ format('ghcr.io/darkydieljob/gestionferreteria:{0}', inputs.version != '' && inputs.version || github.ref_name) }}
       platforms: linux/amd64,linux/arm64
       context: .
       dockerfile: Dockerfile

--- a/.github/workflows/reusable-build-push.yml
+++ b/.github/workflows/reusable-build-push.yml
@@ -1,0 +1,61 @@
+name: Reusable Build & Push (GHCR)
+
+on:
+  workflow_call:
+    inputs:
+      image_repo:
+        required: true
+        type: string
+      tags:
+        required: true
+        type: string
+      platforms:
+        required: false
+        type: string
+        default: linux/amd64
+      context:
+        required: false
+        type: string
+        default: .
+      dockerfile:
+        required: false
+        type: string
+        default: Dockerfile
+      target:
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build_push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          platforms: ${{ inputs.platforms }}
+          tags: ${{ inputs.tags }}
+          target: ${{ inputs.target }}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -324,7 +324,15 @@ jobs:
           if [ "${COLLECTSTATIC}" = "true" ]; then
             docker compose run --rm app python src/manage.py collectstatic --noinput || true
           fi
-          docker compose up -d
+          pwd
+          ls -la
+          ls -la docker-compose.yml docker-compose.yaml compose.yml compose.yaml || true
+          echo "COMPOSE_PROFILES=$COMPOSE_PROFILES"
+          env | sort | grep -E 'COMPOSE|IMAGE_|POSTGRES|DJANGO|ENV' || true
+          docker compose version || true
+          docker compose config --services || true
+          docker compose config --profiles || true
+          docker compose --profile db --profile broker --profile web up -d
 
       - name: Smoke test (curl)
         if: steps.docker_check.outputs.has_docker == 'true' && steps.nodocker_mark.outputs.marked != 'true' && inputs.smoke_check_command == ''

--- a/.github/workflows/standard-version.yml
+++ b/.github/workflows/standard-version.yml
@@ -1,0 +1,39 @@
+name: Standard Version (tag + changelog)
+
+on:
+  push:
+    branches:
+      - release
+
+permissions:
+  contents: write
+
+jobs:
+  standard_version:
+    name: standard-version
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install --no-fund --no-audit
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run standard-version
+        run: npm run release
+
+      - name: Push commit and tags
+        run: git push origin HEAD:release --follow-tags

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Breve descripción del proyecto. Este repositorio se generó a partir de la plan
 - Instalación y comandos rápidos: ver [docs/INSTALACION.md](docs/INSTALACION.md).
 - Índice general de documentación: ver [docs/README.md](docs/README.md).
 - Colas de tareas (Celery + Redis): ver [docs/COLAS_TAREAS.md](docs/COLAS_TAREAS.md).
+- CI/CD (pipelines de simulacro y release): ver [docs/CI_CD.md](docs/CI_CD.md).
 
 ## Colas de tareas (Celery + Redis)
 

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -31,6 +31,21 @@ Ejecutar un release real y despliegue end-to-end.
 4) Deploy a producción.
 5) (Opcional) GitHub Release.
 
+## Migraciones en CD (staging/prod)
+En este repositorio las migraciones están en `.gitignore` y pueden diferir entre entornos.
+Por ese motivo, el deploy **no** depende de archivos de migración versionados y ejecuta las migraciones **in-situ** durante el despliegue.
+
+### Qué se ejecuta
+- `python src/manage.py migrate --run-syncdb --noinput`
+
+### Por qué no se usa `makemigrations`
+- Generar migraciones en runtime requeriría persistir archivos `migrations/` en el host o en un volumen, lo que complica el despliegue y puede generar divergencias difíciles de auditar.
+- `--run-syncdb` permite crear las tablas faltantes sin necesidad de generar archivos de migración.
+
+### Dónde vive
+- Implementado en `.github/workflows/release-cicd.yml` para staging y producción, antes del `docker compose up -d` final.
+
 ### Notas de versionado
 - El proyecto usa `standard-version` (ver `package.json`) para generar `CHANGELOG.md` y tags semánticos.
 - La versión mostrada en UI se toma del `CHANGELOG.md` vía `src/core_app/context_processors.py`.
+- Para que el bump (patch/minor/major) sea correcto, el merge a `release` debe conservar mensajes Conventional Commits (ver `docs/GIT_AGENTES.md`).

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,0 +1,36 @@
+# CI/CD
+
+Este proyecto define dos flujos separados:
+
+## 1) Simulacro (pre-release): `test-pipeline-*`
+
+### Objetivo
+Validar build/push y despliegue en staging sin ejecutar un release real.
+
+### Trigger
+- Tag con prefijo `test-pipeline-*`.
+
+### Resultado
+- Build & push de imagen a GHCR con el tag `test-pipeline-*`.
+- Deploy a staging.
+- NO hay backmerge.
+- NO se despliega a producción por defecto.
+
+## 2) Release real (release): `v*`
+
+### Objetivo
+Ejecutar un release real y despliegue end-to-end.
+
+### Trigger
+- Tag `v*`.
+
+### Secuencia
+1) Build & push de imagen a GHCR con el tag `vX.Y.Z`.
+2) Deploy a staging.
+3) Backmerge automático a `develop`.
+4) Deploy a producción.
+5) (Opcional) GitHub Release.
+
+### Notas de versionado
+- El proyecto usa `standard-version` (ver `package.json`) para generar `CHANGELOG.md` y tags semánticos.
+- La versión mostrada en UI se toma del `CHANGELOG.md` vía `src/core_app/context_processors.py`.

--- a/docs/DJANGOPROYECTS.md
+++ b/docs/DJANGOPROYECTS.md
@@ -256,9 +256,9 @@ python -m pytest -q
 
 Sigue `docs/GIT_AGENTES.md`:
 
-- Nunca trabajes directo en `main` o `pre-release`.
+- Nunca trabajes directo en `release` o `pre-release`.
 - Si estás en `develop`: crea una rama `feature/{area}/{descripcion}` para empezar cambios.
-- Si estás en `pre-release` o `main`:
+- Si estás en `pre-release` o `release`:
   - Cambia a la rama `feature/*` pertinente, o
   - Cambia a `develop` y crea la `feature/*` correspondiente.
 

--- a/docs/GIT_AGENTES.md
+++ b/docs/GIT_AGENTES.md
@@ -3,7 +3,7 @@
 Guía de flujo de trabajo Git para agentes y colaboradores.
 
 ## Convenciones de ramas
-- Ramas largas vivas: `main` (producción), `pre-release` (integración/estabilización), `develop` (base para `feature/*` y `fix/*`)
+- Ramas largas vivas: `release` (producción), `pre-release` (integración/estabilización), `develop` (base para `feature/*` y `fix/*`)
 - Ramas de trabajo: `feature/{app_o_seccion}/{descripcion}`
   - Ejemplos:
     - `feature/core_auth/reset-requests-badge`
@@ -18,7 +18,7 @@ Guía de flujo de trabajo Git para agentes y colaboradores.
   1) `git checkout pre-release && git pull --ff-only`
   2) `git checkout -b fix/{area}/{descripcion}`
   3) Commits atómicos con tipo `fix:` o `docs/chore` si aplica.
-  4) Abrir PR base `pre-release` (no a `main`).
+  4) Abrir PR base `pre-release` (no a `release`).
   5) Tras merge en `pre-release`, sincronizar `develop` (ver Sync) si corresponde.
 
 > Nota (trabajo en solitario): este repositorio está pensado para 1 desarrollador. Se prefieren PRs para historial claro, pero se permiten merges directos cuando no haya revisor, manteniendo las validaciones (tests verdes) y mensajes de commit con Conventional Commits.
@@ -36,7 +36,7 @@ Guía de flujo de trabajo Git para agentes y colaboradores.
 - Si estás en `develop` y vas a empezar cambios:
   - Crea una rama `feature/*` primero. No commits directos en `develop`.
 - Si estás en una `feature/*` y vas a abrir un PR:
-  - Base del PR: `pre-release` (evitar `main`).
+  - Base del PR: `pre-release` (evitar `release`).
   - Título descriptivo y cuerpo con: cambios, pruebas, cobertura, migraciones, breaking changes.
 - Si estás en `develop` y hubo cambios en `pre-release`:
   - Trae esos cambios (merge `origin/pre-release` -> `develop`).
@@ -60,7 +60,7 @@ if branch == develop:
 elif branch.startswith('feature/'):
     create_pr(base='pre-release')
 else:
-    # pre-release o main u otras ramas
+    # pre-release o release u otras ramas
     follow_release_or_sync_rules()
 ```
 
@@ -69,17 +69,17 @@ else:
   - `git checkout develop`
   - `git fetch --all --prune`
   - `git merge --no-ff origin/pre-release -m "Merge pre-release into develop"`
-- Evitar merges a `main` desde `feature/*`: nunca directo a producción.
+- Evitar merges a `release` desde `feature/*`: nunca directo a producción.
 
 ## Releases
-- Objetivo: promover cambios probados en `pre-release` a `main`.
+- Objetivo: promover cambios probados en `pre-release` a `release`.
 - Pasos sugeridos:
   1) Validar CI verde en `pre-release` y aprobación QA.
-  2) Crear PR de `pre-release` -> `main` (revisión final).
-  3) Al mergear en `main`:
+  2) Crear PR de `pre-release` -> `release` (revisión final).
+  3) Al mergear en `release`:
      - Crear tag semántico (ej: `vX.Y.Z`): `git tag -a vX.Y.Z -m "Release vX.Y.Z"` y `git push origin vX.Y.Z`.
      - Opcional: GitHub Release con changelog.
-  4) Desplegar desde `main` (pipeline de CD si existe).
+  4) Desplegar desde `release` (pipeline de CD si existe).
 
 ### Opción directa (solo desarrollador, sin PR)
 - Usar solo cuando no existan revisores y con tests locales verdes.
@@ -87,11 +87,11 @@ else:
 git checkout pre-release
 git pull --ff-only
 # Validar estado (tests/QA)
-git checkout main
+git checkout release
 git pull --ff-only
 git merge --no-ff pre-release -m "release: v1.0.0"
 git tag -a v1.0.0 -m "release: v1.0.0"
-git push origin main
+git push origin release
 git push origin v1.0.0
 # Mantener ramas sincronizadas
 git checkout develop && git pull --ff-only && git merge --no-ff origin/pre-release -m "chore: sync pre-release -> develop (v1.0.0)" && git push
@@ -101,7 +101,7 @@ git checkout develop && git pull --ff-only && git merge --no-ff origin/pre-relea
 - Backport = aplicar cambios ya integrados en una rama más adelantada a otra rama base diferente.
 - Ejemplos:
   - Se mergeó una feature en `pre-release`, pero también se necesita en `develop` (si divergieron): merge `pre-release` -> `develop`.
-  - Se hizo un hotfix en `main` y hay que llevarlo a `pre-release`/`develop`.
+  - Se hizo un hotfix en `release` y hay que llevarlo a `pre-release`/`develop`.
 - Reglas:
   - Preferir merges limpios (`--no-ff`) y resolver conflictos con cuidado.
   - Registrar en el PR/commit que es un backport y el enlace al PR original.
@@ -109,14 +109,14 @@ git checkout develop && git pull --ff-only && git merge --no-ff origin/pre-relea
 ## Buenas prácticas
 - Commits pequeños y descriptivos; mensajes con contexto.
 - Ejecutar tests y coverage localmente antes de push.
-- No empujar directamente a `main` ni `pre-release` sin PR.
+- No empujar directamente a `release` ni `pre-release` sin PR.
 - Limpiar ramas `feature/*` tras merge (borrar local y remoto).
 
 ## Comandos útiles (resumen)
 - Crear feature: `git checkout develop && git pull --ff-only && git checkout -b feature/{app}/{desc}`
 - Abrir PR a pre-release (con gh): `gh pr create --base pre-release --head feature/{app}/{desc} ...`
 - Sync pre-release -> develop: `git checkout develop && git fetch && git merge --no-ff origin/pre-release -m "Merge pre-release into develop"`
-- Release: PR `pre-release` -> `main`, luego tag `vX.Y.Z` y push del tag.
+- Release: PR `pre-release` -> `release`, luego tag `vX.Y.Z` y push del tag.
  - Crear fix: `git checkout pre-release && git pull --ff-only && git checkout -b fix/{area}/{desc}`
  - Abrir PR fix a pre-release: `gh pr create --base pre-release --head fix/{area}/{desc} ...`
 
@@ -130,17 +130,17 @@ Para evitar saltos de versión o doble etiquetado, el versionado y la generació
 - Usar versiones semánticas: `major.minor.patch`.
 
 ### Flujo recomendado
-1) Asegúrate de que `main` contenga el contenido a publicar (mergea `pre-release` -> `main`).
-2) En `main`, ejecutar una sola vez según el tipo de release:
+1) Asegúrate de que `release` contenga el contenido a publicar (mergea `pre-release` -> `release`).
+2) En `release`, ejecutar una sola vez según el tipo de release:
    - Patch: `npx standard-version --release-as patch`
    - Minor: `npx standard-version --release-as minor`
    - Major: `npx standard-version --release-as major`
    (o sin `--release-as` para que infiera por commits)
 3) Publicar commit y tags:
-   - `git push --follow-tags origin main`
+   - `git push --follow-tags origin release`
 4) Sincronizar ramas:
-   - `git checkout develop && git pull --ff-only && git merge --no-ff origin/main -m "chore: sync main -> develop (release)" && git push`
-   - (Opcional) `git checkout pre-release && git pull --ff-only && git merge --no-ff origin/main -m "chore: sync main -> pre-release (release)" && git push`
+   - `git checkout develop && git pull --ff-only && git merge --no-ff origin/release -m "chore: sync release -> develop (release)" && git push`
+   - (Opcional) `git checkout pre-release && git pull --ff-only && git merge --no-ff origin/release -m "chore: sync release -> pre-release (release)" && git push`
 
 ### Merge a `release` (para bump automático)
 Cuando se usa `standard-version` en CI, el bump (patch/minor/major) se infiere a partir de los commits desde el último tag.

--- a/docs/GIT_AGENTES.md
+++ b/docs/GIT_AGENTES.md
@@ -142,6 +142,18 @@ Para evitar saltos de versión o doble etiquetado, el versionado y la generació
    - `git checkout develop && git pull --ff-only && git merge --no-ff origin/main -m "chore: sync main -> develop (release)" && git push`
    - (Opcional) `git checkout pre-release && git pull --ff-only && git merge --no-ff origin/main -m "chore: sync main -> pre-release (release)" && git push`
 
+### Merge a `release` (para bump automático)
+Cuando se usa `standard-version` en CI, el bump (patch/minor/major) se infiere a partir de los commits desde el último tag.
+Para que el cálculo sea correcto, el historial en la rama `release` debe conservar mensajes con Conventional Commits.
+
+Política recomendada:
+- Usar PRs hacia `release` con método **Squash and merge**.
+- El mensaje del squash commit debe seguir Conventional Commits:
+  - `fix:` = patch
+  - `feat:` = minor
+  - `feat!:` o `BREAKING CHANGE:` = major
+- Evitar merges que generen commits tipo `Merge pull request ...`, porque ese mensaje no aporta semántica para inferir el bump.
+
 ### Notas
 - Si por error se creó un tag manual y luego se ejecutó `standard-version`, puede generarse un salto (p.ej. 1.1.0 → 1.2.0). Evitar mezclar ambos métodos.
 - Los commits deben seguir Conventional Commits para que `standard-version` pueda inferir el tipo de release correctamente.

--- a/docs/PAUTAS_AGENTES.md
+++ b/docs/PAUTAS_AGENTES.md
@@ -165,12 +165,12 @@ Resumen operativo del nuevo flujo seguro sin correo electrónico, con verificaci
 - Ramas largas vivas:
   - `develop`: base para ramas `feature/*` y `fix/*` (trabajo diario).
   - `pre-release`: integración y estabilización (staging) antes de producción.
-  - `main`: producción (solo versiones liberadas).
+  - `release`: producción (solo versiones liberadas).
 - Ramas de trabajo: `feature/{app_o_seccion}/{descripcion}` o `fix/{area}/{descripcion}` creadas desde `develop`.
 - Sincronización: mantener `develop` sincronizado periódicamente con `pre-release`.
 - Releases (resumen):
-  - Preferido: PR de `pre-release` -> `main`, tag `vX.Y.Z`, deploy.
-  - Solo-dev (sin PR): merge `pre-release` -> `main`, tag y push del tag; luego sincronizar `develop`.
+  - Preferido: PR de `pre-release` -> `release`, tag `vX.Y.Z`, deploy.
+  - Solo-dev (sin PR): merge `pre-release` -> `release`, tag y push del tag; luego sincronizar `develop`.
 - Referencia detallada: ver `docs/GIT_AGENTES.md`.
 
 ## 8) Atajos útiles

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,10 @@ Bienvenido a la documentación central del proyecto. Usa este índice para naveg
   - Pautas operativas para agentes
     - docs/PAUTAS_AGENTES.md
 
+- CI/CD
+  - Pipelines de simulacro (test-pipeline-*) y release real (v*)
+    - docs/CI_CD.md
+
 - Funcionalidades del sistema
   - Colas de tareas (Celery + Redis)
     - docs/COLAS_TAREAS.md

--- a/docs/RECETAS_DEPLOY.md
+++ b/docs/RECETAS_DEPLOY.md
@@ -15,7 +15,7 @@ docker compose build
 
 ## Migraciones (previas al up -d)
 ```bash
-docker compose run --rm app python src/manage.py migrate
+docker compose run --rm app python src/manage.py migrate --run-syncdb --noinput
 ```
 
 ## Arranque (ordenado por healthchecks)
@@ -36,6 +36,7 @@ docker compose up -d [--profile db] [--profile broker] [--profile worker]
   - worker: `python src/manage.py check`
 - depends_on con `condition: service_healthy` asegura orden de arranque y tolerancia a latencia.
 - Tradeoff: pequeño tiempo extra (migrate + healthchecks) a cambio de mayor estabilidad.
+- Migraciones: en entornos donde las migraciones no se versionan, `--run-syncdb` permite crear tablas faltantes sin depender de archivos `migrations/`.
 
 ---
 

--- a/docs/adr/0002-adopcion-github-template-repository.md
+++ b/docs/adr/0002-adopcion-github-template-repository.md
@@ -18,7 +18,7 @@ Convertiremos "DjangoProyects" en un **GitHub Template Repository** para usarlo 
 ## Consecuencias
 ### Positivas
 - **Simplicidad**: Generar nuevos proyectos con un clic en GitHub, sin copias manuales.
-- **Compatibilidad**: Integra con el flujo Git actual (`develop`, `pre-release`, `main`, Conventional Commits).
+- **Compatibilidad**: Integra con el flujo Git actual (`develop`, `pre-release`, `release`, Conventional Commits).
 - **Flexibilidad**: Permite sincronizar selectivamente (merge/cherry-pick) cambios generales (base → derivados) o específicos (derivado → base).
 - **Mantenimiento ligero**: Ideal para un desarrollador solo, sin herramientas adicionales.
 - **Reusabilidad**: Mejoras en apps comunes (p.ej., `core_utils`) pueden backportearse al base para futuros proyectos.
@@ -50,7 +50,7 @@ Convertiremos "DjangoProyects" en un **GitHub Template Repository** para usarlo 
    - Usar "Use this template" para crear repos como "Ferreteria_v4" o "TeatroBar_v2".
    - Clonar localmente, personalizar (p.ej., `INSTALLED_APPS`, `.env`), y agregar apps específicas.
 3. **Sincronizar Cambios**:
-   - **Base → Derivado**: En el derivado, agregar remote: `git remote add base https://github.com/tu-usuario/DjangoProyects.git`, luego `git fetch base` y `git merge base/main` (o `git cherry-pick <commit>` para cambios específicos).
+   - **Base → Derivado**: En el derivado, agregar remote: `git remote add base https://github.com/tu-usuario/DjangoProyects.git`, luego `git fetch base` y `git merge base/release` (o `git cherry-pick <commit>` para cambios específicos).
    - **Derivado → Base**: Crear PR desde el derivado al base (o cherry-pick commits). Ejemplo: mover templates de calendarios de TeatroBar_v2 a `core_utils` en el base.
    - Resolver conflictos en archivos sensibles (p.ej., `settings.py`, `urls.py`).
 4. **Automatización Parcial**:
@@ -58,7 +58,7 @@ Convertiremos "DjangoProyects" en un **GitHub Template Repository** para usarlo 
    - Ejemplo: Agregar `git remote add base <url> && git fetch base` en el script.
 5. **Documentación**:
    - Actualizar `README.md` y `docs/INSTALACION.md` con instrucciones para usar el template y sincronizar.
-   - Ejemplo: "Para sincronizar con el base: `git remote add base <url> && git fetch base && git merge base/main`".
+   - Ejemplo: "Para sincronizar con el base: `git remote add base <url> && git fetch base && git merge base/release`".
 
 ## Referencias
 - [GitHub Template Repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)

--- a/docs/adr/DjangoProyect/0023-implementacion-despliegues.md
+++ b/docs/adr/DjangoProyect/0023-implementacion-despliegues.md
@@ -36,7 +36,7 @@ Tradeoffs: Disciplina en syncs (no mergear archivos versionados); mitigado con d
 Pasos conceptuales para la implementación
 
 Estructura del repositorio y ramas
-Ramas: develop para features, pre-release para staging, main para producción estable.
+Ramas: develop para features, pre-release para staging, release para producción estable.
 Políticas: validación previa a merges; disociación en versionado para evitar overwrites.
 
 Triggers y eventos

--- a/docs/adr/GestionFerreteria/0025-imagenes-inmutables-y-despliegue-via-registry.md
+++ b/docs/adr/GestionFerreteria/0025-imagenes-inmutables-y-despliegue-via-registry.md
@@ -145,7 +145,7 @@ steps:
   - Producción: `IMAGE_TAG=vX.Y.Z` (pinneado) y gate manual.
 
 Notas:
-- Los runners de staging y prod deben apuntar a la rama `deploy`. Se sugiere mantener `main` como histórica/compatibilidad y no renombrarla de inmediato; `release` asume el rol de rama de releases estables para automatizar publish y etiquetado. Una vez estabilizado el flujo, evaluar si `main` queda obsoleta o se alinea a `release`.
+- Los runners de staging y prod deben apuntar a la rama `deploy`. En este repositorio, la rama de producción es `release` y `main` queda como rama histórica/legacy.
 - En producción, no usar `latest` en `IMAGE_TAG`. Se permite co-tag `latest` al publicar, pero `deploy` debe consumir `vX.Y.Z`.
 
 ### Riesgos y mitigaciones

--- a/objetives.md
+++ b/objetives.md
@@ -42,7 +42,7 @@ Este documento detalla una checklist secuencial para completar ADR-0002. Cada í
 
 4. **Demostrar Sincronización Base → Derivado**  
    - **Descripción**: Probar la propagación de cambios del base a un derivado.  
-   - **Acciones**: En el base, hacer un cambio simple (p.ej., agregar un comentario en `core_utils/helpers.py`). Commit y push a `main`. En el derivado, agregar remote: `git remote add base https://github.com/tu-usuario/DjangoProyects.git`, fetch, y merge: `git fetch base && git merge base/main`.  
+   - **Acciones**: En el base, hacer un cambio simple (p.ej., agregar un comentario en `core_utils/helpers.py`). Commit y push a `release`. En el derivado, agregar remote: `git remote add base https://github.com/tu-usuario/DjangoProyects.git`, fetch, y merge: `git fetch base && git merge base/release`.  
    - **Verificación**: [ ] El cambio aparece en el derivado sin conflictos mayores; tests pasan (`pytest -q`). **Evidencia**: `git log` mostrando el merge.
 
 5. **Demostrar Sincronización Derivado → Base**  
@@ -57,7 +57,7 @@ Este documento detalla una checklist secuencial para completar ADR-0002. Cada í
 
 7. **Actualizar Documentación**  
    - **Descripción**: Documentar el nuevo flujo en archivos clave.  
-   - **Acciones**: Actualizar `README.md` con sección "Usar como Template" (instrucciones para generar derivados y sincronizar). Actualizar `docs/INSTALACION.md` con pasos para sync (p.ej., "Para sincronizar con el base: `git remote add base <url> && git fetch base && git merge base/main`").  
+   - **Acciones**: Actualizar `README.md` con sección "Usar como Template" (instrucciones para generar derivados y sincronizar). Actualizar `docs/INSTALACION.md` con pasos para sync (p.ej., "Para sincronizar con el base: `git remote add base <url> && git fetch base && git merge base/release`").  
    - **Verificación**: [ ] Documentos reflejan el flujo; links a ADR-0002. **Evidencia**: Commit con actualizaciones.
 
 8. **Validar Flujo Completo y Cleanup**  


### PR DESCRIPTION
Incluye:\n- Migraciones in-situ en deploy (migrate --run-syncdb --noinput)\n- Workflow standard-version al hacer push/merge a release\n- Documentación y alineación de ramas (release como prod; main legacy)\n- Desactivación de backmerge legacy por tags\n\nNota:\n- Para bump automático correcto, mergear a release via Squash and merge con mensaje Conventional Commit.