### PR TITLE
chore: realign version to 2.0.6 and tag after build

### DIFF
--- a/.github/workflows/build-pre-release.yml
+++ b/.github/workflows/build-pre-release.yml
@@ -2,7 +2,8 @@ name: Build & Push (pre-release)
 
 on:
   push:
-    branches: [pre-release]  # Se ejecuta al pushear/mergear a pre-release (no afecta feature/*)
+    tags:
+      - 'test-pipeline-*'
   workflow_dispatch: {}       # Permite ejecución manual
 
 permissions:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,10 +1,6 @@
 name: Build & Push (release/tag)
 
 on:
-  push:
-    branches: [release]       # Se ejecuta al pushear/mergear a release
-    # tags:
-    #   - 'v*'                  # Manejado por release-cicd.yml (build + deploy) para evitar doble ejecución
   workflow_dispatch: {}       # Permite ejecución manual
 
 permissions:

--- a/.github/workflows/standard-version.yml
+++ b/.github/workflows/standard-version.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   standard_version:
@@ -32,8 +33,46 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Run standard-version
-        run: npm run release
+      - name: Run standard-version (no tag)
+        run: npx standard-version --skip.tag
 
-      - name: Push commit and tags
-        run: git push origin HEAD:release --follow-tags
+      - name: Resolve release version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Push release commit
+        run: git push origin HEAD:release
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image (vX.Y.Z)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ format('ghcr.io/darkydieljob/gestionferreteria:{0}', steps.version.outputs.tag) }}
+
+      - name: Create and push git tag (after build)
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.version.outputs.tag }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          git tag -a "$TAG" -m "chore(release): $VERSION"
+          git push origin "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.0.6](https://github.com/DarkyDieLJob/GestionFerreteria/compare/v2.0.5...v2.0.6) (2026-02-03)
+
+### Notes
+
+* Reconstrucción de versionado por desfase: el tag `v2.0.6` ya existía en el remoto/GitHub, pero la rama seguía en `2.0.5`.
+
 ### [2.0.5](https://github.com/DarkyDieLJob/GestionFerreteria/compare/v2.0.4...v2.0.5) (2026-01-13)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gestion-ferreteria",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "scripts": {
     "release": "standard-version",


### PR DESCRIPTION
Hotfix directo en pre-release para corregir desfase con el tag existente v2.0.6 y evitar colisión en standard-version.\n\nIncluye:\n- package.json: 2.0.5 -> 2.0.6\n- CHANGELOG.md: nota aclaratoria (reconstrucción por desfase de tag)\n- standard-version.yml: ahora NO crea tag hasta después de build & push a GHCR\n- build-release.yml: se deja solo manual para evitar builds duplicados\n\nLuego de mergear a release, el próximo release debería crear v2.0.7 sin conflictos y disparar release-cicd (deploy en runners locales).