### PR TITLE
ci: dispatch release-cicd after tagging

### DIFF
--- a/.github/workflows/standard-version.yml
+++ b/.github/workflows/standard-version.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  actions: write
 
 jobs:
   standard_version:

--- a/.github/workflows/standard-version.yml
+++ b/.github/workflows/standard-version.yml
@@ -76,3 +76,17 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           git tag -a "$TAG" -m "chore(release): $VERSION"
           git push origin "$TAG"
+
+      - name: Dispatch deploy workflow (release-cicd)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release-cicd.yml',
+              ref: 'release',
+              inputs: {
+                version: '${{ steps.version.outputs.tag }}'
+              }
+            })


### PR DESCRIPTION
Fix: el tag v* pusheado desde Actions (GITHUB_TOKEN) puede NO disparar workflows on: push.tags.\n\nSe agrega en standard-version.yml:\n- permissions: actions: write\n- step que dispara release-cicd.yml via workflow_dispatch pasando inputs.version=vX.Y.Z\n\nResultado: luego de build&push y de crear el tag, se ejecuta el deploy en runners self-hosted (staging/prod) sin depender del evento push tag.