### PR TITLE
ci: run prod steps when dispatched with version

### DIFF
--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -123,7 +123,7 @@ jobs:
   backmerge_release_to_develop:
     name: Back-merge release -> develop
     needs: [deploy_staging]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(inputs.version, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -158,7 +158,7 @@ jobs:
   deploy_prod:
     name: Deploy (production)
     needs: [backmerge_release_to_develop]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(inputs.version, 'v')
     environment:
       name: production
     runs-on: [self-hosted, prod, docker]


### PR DESCRIPTION
Fix: cuando release-cicd.yml se ejecuta via workflow_dispatch (disparado desde standard-version), github.ref es refs/heads/release y los jobs con if: startsWith(github.ref, 'refs/tags/v') quedaban SKIPPED.\n\nCambio:\n- backmerge_release_to_develop y deploy_prod ahora corren si inputs.version empieza con 'v' (además del caso tag).\n\nResultado: el deploy a producción y el backmerge a develop vuelven a ejecutarse correctamente también en ejecuciones dispatched.