### PR TITLE
ci: cache npm for standard-version

### DIFF
--- a/.github/workflows/standard-version.yml
+++ b/.github/workflows/standard-version.yml
@@ -26,8 +26,13 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install dependencies
-        run: npm install --no-fund --no-audit
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Optimización: en standard-version.yml se agrega cache de npm (~/.npm) y se elimina npm install. Se ejecuta standard-version vía npx (descarga/cachea el paquete), reduciendo el tiempo del pipeline sin necesidad de package-lock.json.