### PR TITLE
ci: auto-recover migrations and fix compose healthcheck vars

### DIFF
--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -135,14 +135,22 @@ jobs:
           if "${migrate_cmd[@]}"; then
             exit 0
           fi
-          echo "Migration failed; attempting targeted recovery for core_auth:0002..." >&2
+          echo "Migration failed; attempting automatic recovery for DuplicateTable (fake failing migration + retry)..." >&2
           set +e
           out=$("${migrate_cmd[@]}" 2>&1)
           code=$?
           set -e
           echo "$out" >&2
-          if echo "$out" | grep -Fq 'relation "core_auth_coreauthprofile" already exists'; then
-            docker compose run --rm app python src/manage.py migrate core_auth 0002 --fake
+          if echo "$out" | grep -Eqi 'already exists|DuplicateTable'; then
+            mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
+            if [ -z "$mig" ]; then
+              echo "Could not detect failing migration from output; aborting." >&2
+              exit $code
+            fi
+            app=$(echo "$mig" | awk '{print $1}')
+            name=$(echo "$mig" | awk '{print $2}')
+            echo "Detected failing migration: $app $name. Marking as fake and retrying..." >&2
+            docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
             "${migrate_cmd[@]}"
           else
             exit $code
@@ -302,14 +310,22 @@ jobs:
           if "${migrate_cmd[@]}"; then
             exit 0
           fi
-          echo "Migration failed; attempting targeted recovery for core_auth:0002..." >&2
+          echo "Migration failed; attempting automatic recovery for DuplicateTable (fake failing migration + retry)..." >&2
           set +e
           out=$("${migrate_cmd[@]}" 2>&1)
           code=$?
           set -e
           echo "$out" >&2
-          if echo "$out" | grep -Fq 'relation "core_auth_coreauthprofile" already exists'; then
-            docker compose run --rm app python src/manage.py migrate core_auth 0002 --fake
+          if echo "$out" | grep -Eqi 'already exists|DuplicateTable'; then
+            mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
+            if [ -z "$mig" ]; then
+              echo "Could not detect failing migration from output; aborting." >&2
+              exit $code
+            fi
+            app=$(echo "$mig" | awk '{print $1}')
+            name=$(echo "$mig" | awk '{print $2}')
+            echo "Detected failing migration: $app $name. Marking as fake and retrying..." >&2
+            docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
             "${migrate_cmd[@]}"
           else
             exit $code

--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -128,7 +128,25 @@ jobs:
       - name: Run migrations (in-situ)
         env:
           COMPOSE_PROFILES: db,broker,web
-        run: docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput
+        shell: bash
+        run: |
+          set -euo pipefail
+          migrate_cmd=(docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput)
+          if "${migrate_cmd[@]}"; then
+            exit 0
+          fi
+          echo "Migration failed; attempting targeted recovery for core_auth:0002..." >&2
+          set +e
+          out=$("${migrate_cmd[@]}" 2>&1)
+          code=$?
+          set -e
+          echo "$out" >&2
+          if echo "$out" | grep -Fq 'relation "core_auth_coreauthprofile" already exists'; then
+            docker compose run --rm app python src/manage.py migrate core_auth 0002 --fake
+            "${migrate_cmd[@]}"
+          else
+            exit $code
+          fi
 
       - name: Compose up (with profiles)
         env:
@@ -277,7 +295,25 @@ jobs:
       - name: Run migrations (in-situ)
         env:
           COMPOSE_PROFILES: db,broker,web
-        run: docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput
+        shell: bash
+        run: |
+          set -euo pipefail
+          migrate_cmd=(docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput)
+          if "${migrate_cmd[@]}"; then
+            exit 0
+          fi
+          echo "Migration failed; attempting targeted recovery for core_auth:0002..." >&2
+          set +e
+          out=$("${migrate_cmd[@]}" 2>&1)
+          code=$?
+          set -e
+          echo "$out" >&2
+          if echo "$out" | grep -Fq 'relation "core_auth_coreauthprofile" already exists'; then
+            docker compose run --rm app python src/manage.py migrate core_auth 0002 --fake
+            "${migrate_cmd[@]}"
+          else
+            exit $code
+          fi
 
       - name: Compose up (with profiles)
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fix CD sin intervención manual:\n\n- release-cicd.yml: el paso de migraciones ahora reintenta automáticamente si detecta , ejecutando  y luego reintentando .\n- docker-compose.yml: healthcheck de Postgres usa  para evitar interpolación por Docker Compose y warnings de variables en blanco.\n\nObjetivo: evitar fallos por desfase de historial de migraciones en DBs existentes sin tocar datos ni requerir inputs manuales.