### PR TITLE
ci: wait for db health before migrations

### DIFF
--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -105,6 +105,31 @@ jobs:
           COMPOSE_PROFILES: db,broker,web
         run: docker compose --profile db --profile broker up -d db redis
 
+      - name: Wait for DB health (diagnostics)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gestionferreteria-db 2>/dev/null || echo 'missing')
+            echo "db health/status: $status"
+            if [ "$status" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "$status" = "unhealthy" ] || [ "$status" = "exited" ] || [ "$status" = "missing" ]; then
+              echo "DB is not healthy ($status). Showing db logs..." >&2
+              docker compose logs --no-color db || true
+              docker inspect gestionferreteria-db || true
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "DB did not become healthy in time. Showing db logs..." >&2
+          docker compose logs --no-color db || true
+          docker inspect gestionferreteria-db || true
+          exit 1
+
       - name: Fake migrations (optional)
         if: inputs.fake_migrations != ''
         env:
@@ -132,29 +157,27 @@ jobs:
         run: |
           set -euo pipefail
           migrate_cmd=(docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput)
-          if "${migrate_cmd[@]}"; then
-            exit 0
-          fi
-          echo "Migration failed; attempting automatic recovery for DuplicateTable (fake failing migration + retry)..." >&2
           set +e
           out=$("${migrate_cmd[@]}" 2>&1)
           code=$?
           set -e
+          if [ $code -eq 0 ]; then
+            exit 0
+          fi
           echo "$out" >&2
-          if echo "$out" | grep -Eqi 'already exists|DuplicateTable'; then
-            mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
-            if [ -z "$mig" ]; then
-              echo "Could not detect failing migration from output; aborting." >&2
-              exit $code
-            fi
-            app=$(echo "$mig" | awk '{print $1}')
-            name=$(echo "$mig" | awk '{print $2}')
-            echo "Detected failing migration: $app $name. Marking as fake and retrying..." >&2
-            docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
-            "${migrate_cmd[@]}"
-          else
+          if ! echo "$out" | grep -Eqi 'already exists|DuplicateTable'; then
             exit $code
           fi
+          mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
+          if [ -z "$mig" ]; then
+            echo "DuplicateTable detected but could not parse failing migration (no 'Applying ...' line). Aborting." >&2
+            exit $code
+          fi
+          app=$(echo "$mig" | awk '{print $1}')
+          name=$(echo "$mig" | awk '{print $2}')
+          echo "Migration failed due to DuplicateTable. Faking migration: $app $name and retrying..." >&2
+          docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
+          "${migrate_cmd[@]}"
 
       - name: Compose up (with profiles)
         env:
@@ -280,6 +303,32 @@ jobs:
           COMPOSE_PROFILES: db,broker,web
         run: docker compose --profile db --profile broker up -d db redis
 
+      - name: Wait for DB health (diagnostics)
+        env:
+          COMPOSE_PROFILES: db,broker,web
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gestionferreteria-db 2>/dev/null || echo 'missing')
+            echo "db health/status: $status"
+            if [ "$status" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "$status" = "unhealthy" ] || [ "$status" = "exited" ] || [ "$status" = "missing" ]; then
+              echo "DB is not healthy ($status). Showing db logs..." >&2
+              docker compose logs --no-color db || true
+              docker inspect gestionferreteria-db || true
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "DB did not become healthy in time. Showing db logs..." >&2
+          docker compose logs --no-color db || true
+          docker inspect gestionferreteria-db || true
+          exit 1
+
+
       - name: Fake migrations (optional)
         if: inputs.fake_migrations != ''
         env:
@@ -307,29 +356,27 @@ jobs:
         run: |
           set -euo pipefail
           migrate_cmd=(docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput)
-          if "${migrate_cmd[@]}"; then
-            exit 0
-          fi
-          echo "Migration failed; attempting automatic recovery for DuplicateTable (fake failing migration + retry)..." >&2
           set +e
           out=$("${migrate_cmd[@]}" 2>&1)
           code=$?
           set -e
           echo "$out" >&2
-          if echo "$out" | grep -Eqi 'already exists|DuplicateTable'; then
-            mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
-            if [ -z "$mig" ]; then
-              echo "Could not detect failing migration from output; aborting." >&2
-              exit $code
-            fi
-            app=$(echo "$mig" | awk '{print $1}')
-            name=$(echo "$mig" | awk '{print $2}')
-            echo "Detected failing migration: $app $name. Marking as fake and retrying..." >&2
-            docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
-            "${migrate_cmd[@]}"
-          else
+          if [ $code -eq 0 ]; then
+            exit 0
+          fi
+          if ! echo "$out" | grep -Eqi 'DuplicateTable|already exists'; then
             exit $code
           fi
+          mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
+          if [ -z "$mig" ]; then
+            echo "DuplicateTable detected but could not parse failing migration (no 'Applying ...' line). Aborting." >&2
+            exit $code
+          fi
+          app=$(echo "$mig" | awk '{print $1}')
+          name=$(echo "$mig" | awk '{print $2}')
+          echo "Migration failed due to DuplicateTable. Faking migration: $app $name and retrying..." >&2
+          docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
+          "${migrate_cmd[@]}"
 
       - name: Compose up (with profiles)
         env:

--- a/.github/workflows/release-cicd.yml
+++ b/.github/workflows/release-cicd.yml
@@ -34,164 +34,21 @@ jobs:
   deploy_staging:
     name: Deploy (staging)
     needs: [build]
-    environment:
-      name: staging
-    runs-on: [self-hosted, stage, docker]
+    uses: ./.github/workflows/reusable-compose-deploy-ghcr.yml
+    secrets: inherit
     permissions:
       contents: read
       packages: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Verify Docker availability
-        shell: bash
-        run: |
-          set -euo pipefail
-          command -v docker >/dev/null 2>&1 || { echo "docker not found on runner (PATH). Install Docker and ensure runner user can execute it."; exit 1; }
-          docker --version
-          docker compose version || true
-
-      - name: Resolve IMAGE_TAG
-        id: resolve_tag
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG_INPUT="${{ inputs.version }}"
-          REF_NAME="${{ github.ref_name }}"
-          if [ -n "${TAG_INPUT}" ]; then
-            TAG="${TAG_INPUT}"
-          else
-            TAG="${REF_NAME}"
-          fi
-          if ! echo "$TAG" | grep -Eq '^(v|test-pipeline-)'; then
-            echo "Refusing to deploy: resolved tag '$TAG' does not look like a supported release tag (v* or test-pipeline-*). Provide inputs.version or run on a matching tag." >&2
-            exit 1
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Docker login to GHCR
-        env:
-          CR_PAT: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Set image environment
-        run: |
-          echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
-          echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
-          echo "IMAGE_TAG=${{ steps.resolve_tag.outputs.tag }}" >> $GITHUB_ENV
-
-      - name: Pull images (with profiles)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        run: docker compose pull
-
-      - name: Compose diagnostics (before up)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          pwd
-          ls -la
-          ls -la docker-compose.yml docker-compose.yaml compose.yml compose.yaml || true
-          echo "COMPOSE_PROFILES=$COMPOSE_PROFILES"
-          env | sort | grep -E 'COMPOSE|IMAGE_|POSTGRES|DJANGO|ENV' || true
-          docker compose version || true
-          docker compose config --services || true
-          docker compose config --profiles || true
-
-      - name: Compose up deps (db + broker)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        run: docker compose --profile db --profile broker up -d db redis
-
-      - name: Wait for DB health (diagnostics)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          set -euo pipefail
-          for i in $(seq 1 30); do
-            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gestionferreteria-db 2>/dev/null || echo 'missing')
-            echo "db health/status: $status"
-            if [ "$status" = "healthy" ]; then
-              exit 0
-            fi
-            if [ "$status" = "unhealthy" ] || [ "$status" = "exited" ] || [ "$status" = "missing" ]; then
-              echo "DB is not healthy ($status). Showing db logs..." >&2
-              docker compose logs --no-color db || true
-              docker inspect gestionferreteria-db || true
-              exit 1
-            fi
-            sleep 2
-          done
-          echo "DB did not become healthy in time. Showing db logs..." >&2
-          docker compose logs --no-color db || true
-          docker inspect gestionferreteria-db || true
-          exit 1
-
-      - name: Fake migrations (optional)
-        if: inputs.fake_migrations != ''
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          set -euo pipefail
-          IFS=',' read -ra ITEMS <<< "${{ inputs.fake_migrations }}"
-          for item in "${ITEMS[@]}"; do
-            item_trimmed=$(echo "$item" | xargs)
-            app=${item_trimmed%%:*}
-            mig=${item_trimmed##*:}
-            if [ -z "$app" ] || [ -z "$mig" ] || [ "$app" = "$mig" ]; then
-              echo "Invalid fake migration entry: '$item_trimmed' (expected app:migration)" >&2
-              exit 1
-            fi
-            echo "Faking migration: $app $mig"
-            docker compose run --rm app python src/manage.py migrate "$app" "$mig" --fake
-          done
-
-      - name: Run migrations (in-situ)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          set -euo pipefail
-          migrate_cmd=(docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput)
-          set +e
-          out=$("${migrate_cmd[@]}" 2>&1)
-          code=$?
-          set -e
-          if [ $code -eq 0 ]; then
-            exit 0
-          fi
-          echo "$out" >&2
-          if ! echo "$out" | grep -Eqi 'already exists|DuplicateTable'; then
-            exit $code
-          fi
-          mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
-          if [ -z "$mig" ]; then
-            echo "DuplicateTable detected but could not parse failing migration (no 'Applying ...' line). Aborting." >&2
-            exit $code
-          fi
-          app=$(echo "$mig" | awk '{print $1}')
-          name=$(echo "$mig" | awk '{print $2}')
-          echo "Migration failed due to DuplicateTable. Faking migration: $app $name and retrying..." >&2
-          docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
-          "${migrate_cmd[@]}"
-
-      - name: Compose up (with profiles)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        run: docker compose --profile db --profile broker --profile web up -d --remove-orphans
-
-      - name: Smoke check
-        run: |
-          set -euo pipefail
-          end=$((SECONDS+120))
-          until curl -fsS http://127.0.0.1:8001/ >/dev/null; do
-            [ $SECONDS -ge $end ] && { echo "Smoke failed"; docker compose logs --no-color app || true; exit 1; }
-            sleep 3
-          done
+    with:
+      environment_name: staging
+      runner_labels_json: '["self-hosted","stage","docker"]'
+      image_registry: ghcr.io
+      image_repo: darkydieljob/gestionferreteria
+      image_tag: ${{ inputs.version != '' && inputs.version || github.ref_name }}
+      profiles: db,broker,web
+      fake_migrations: ${{ inputs.fake_migrations }}
+      smoke_url: http://127.0.0.1:8001/
+      smoke_timeout_seconds: 120
 
   backmerge_release_to_develop:
     name: Back-merge release -> develop
@@ -232,162 +89,18 @@ jobs:
     name: Deploy (production)
     needs: [backmerge_release_to_develop]
     if: startsWith(github.ref, 'refs/tags/v') || startsWith(inputs.version, 'v')
-    environment:
-      name: production
-    runs-on: [self-hosted, prod, docker]
+    uses: ./.github/workflows/reusable-compose-deploy-ghcr.yml
+    secrets: inherit
     permissions:
       contents: read
       packages: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Verify Docker availability
-        shell: bash
-        run: |
-          set -euo pipefail
-          command -v docker >/dev/null 2>&1 || { echo "docker not found on runner (PATH). Install Docker and ensure runner user can execute it."; exit 1; }
-          docker --version
-          docker compose version || true
-
-      - name: Resolve IMAGE_TAG
-        id: resolve_tag
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG_INPUT="${{ inputs.version }}"
-          REF_NAME="${{ github.ref_name }}"
-          if [ -n "${TAG_INPUT}" ]; then
-            TAG="${TAG_INPUT}"
-          else
-            TAG="${REF_NAME}"
-          fi
-          if ! echo "$TAG" | grep -Eq '^(v|test-pipeline-)'; then
-            echo "Refusing to deploy: resolved tag '$TAG' does not look like a supported release tag (v* or test-pipeline-*). Provide inputs.version or run on a matching tag." >&2
-            exit 1
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Docker login to GHCR
-        env:
-          CR_PAT: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$CR_PAT" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Set image environment
-        run: |
-          echo "IMAGE_REGISTRY=ghcr.io" >> $GITHUB_ENV
-          echo "IMAGE_REPO=darkydieljob/gestionferreteria" >> $GITHUB_ENV
-          echo "IMAGE_TAG=${{ steps.resolve_tag.outputs.tag }}" >> $GITHUB_ENV
-
-      - name: Pull images (with profiles)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        run: docker compose pull
-
-      - name: Compose diagnostics (before up)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          pwd
-          ls -la
-          ls -la docker-compose.yml docker-compose.yaml compose.yml compose.yaml || true
-          echo "COMPOSE_PROFILES=$COMPOSE_PROFILES"
-          env | sort | grep -E 'COMPOSE|IMAGE_|POSTGRES|DJANGO|ENV' || true
-          docker compose version || true
-          docker compose config --services || true
-          docker compose config --profiles || true
-
-      - name: Compose up deps (db + broker)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        run: docker compose --profile db --profile broker up -d db redis
-
-      - name: Wait for DB health (diagnostics)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          set -euo pipefail
-          for i in $(seq 1 30); do
-            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gestionferreteria-db 2>/dev/null || echo 'missing')
-            echo "db health/status: $status"
-            if [ "$status" = "healthy" ]; then
-              exit 0
-            fi
-            if [ "$status" = "unhealthy" ] || [ "$status" = "exited" ] || [ "$status" = "missing" ]; then
-              echo "DB is not healthy ($status). Showing db logs..." >&2
-              docker compose logs --no-color db || true
-              docker inspect gestionferreteria-db || true
-              exit 1
-            fi
-            sleep 2
-          done
-          echo "DB did not become healthy in time. Showing db logs..." >&2
-          docker compose logs --no-color db || true
-          docker inspect gestionferreteria-db || true
-          exit 1
-
-
-      - name: Fake migrations (optional)
-        if: inputs.fake_migrations != ''
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          set -euo pipefail
-          IFS=',' read -ra ITEMS <<< "${{ inputs.fake_migrations }}"
-          for item in "${ITEMS[@]}"; do
-            item_trimmed=$(echo "$item" | xargs)
-            app=${item_trimmed%%:*}
-            mig=${item_trimmed##*:}
-            if [ -z "$app" ] || [ -z "$mig" ] || [ "$app" = "$mig" ]; then
-              echo "Invalid fake migration entry: '$item_trimmed' (expected app:migration)" >&2
-              exit 1
-            fi
-            echo "Faking migration: $app $mig"
-            docker compose run --rm app python src/manage.py migrate "$app" "$mig" --fake
-          done
-
-      - name: Run migrations (in-situ)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        shell: bash
-        run: |
-          set -euo pipefail
-          migrate_cmd=(docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput)
-          set +e
-          out=$("${migrate_cmd[@]}" 2>&1)
-          code=$?
-          set -e
-          echo "$out" >&2
-          if [ $code -eq 0 ]; then
-            exit 0
-          fi
-          if ! echo "$out" | grep -Eqi 'DuplicateTable|already exists'; then
-            exit $code
-          fi
-          mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
-          if [ -z "$mig" ]; then
-            echo "DuplicateTable detected but could not parse failing migration (no 'Applying ...' line). Aborting." >&2
-            exit $code
-          fi
-          app=$(echo "$mig" | awk '{print $1}')
-          name=$(echo "$mig" | awk '{print $2}')
-          echo "Migration failed due to DuplicateTable. Faking migration: $app $name and retrying..." >&2
-          docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
-          "${migrate_cmd[@]}"
-
-      - name: Compose up (with profiles)
-        env:
-          COMPOSE_PROFILES: db,broker,web
-        run: docker compose --profile db --profile broker --profile web up -d --remove-orphans
-
-      - name: Smoke check
-        run: |
-          set -euo pipefail
-          end=$((SECONDS+120))
-          until curl -fsS http://127.0.0.1:8001/ >/dev/null; do
-            [ $SECONDS -ge $end ] && { echo "Smoke failed"; docker compose logs --no-color app || true; exit 1; }
-            sleep 3
-          done
+    with:
+      environment_name: production
+      runner_labels_json: '["self-hosted","prod","docker"]'
+      image_registry: ghcr.io
+      image_repo: darkydieljob/gestionferreteria
+      image_tag: ${{ inputs.version != '' && inputs.version || github.ref_name }}
+      profiles: db,broker,web
+      fake_migrations: ${{ inputs.fake_migrations }}
+      smoke_url: http://127.0.0.1:8001/
+      smoke_timeout_seconds: 120

--- a/.github/workflows/reusable-compose-deploy-ghcr.yml
+++ b/.github/workflows/reusable-compose-deploy-ghcr.yml
@@ -1,0 +1,186 @@
+name: Reusable Compose Deploy (GHCR)
+
+on:
+  workflow_call:
+    inputs:
+      environment_name:
+        required: true
+        type: string
+      runner_labels_json:
+        required: true
+        type: string
+      image_registry:
+        required: false
+        type: string
+        default: ghcr.io
+      image_repo:
+        required: true
+        type: string
+      image_tag:
+        required: true
+        type: string
+      profiles:
+        required: false
+        type: string
+        default: db,broker,web
+      fake_migrations:
+        required: false
+        type: string
+        default: ''
+      smoke_url:
+        required: false
+        type: string
+        default: http://127.0.0.1:8001/
+      smoke_timeout_seconds:
+        required: false
+        type: number
+        default: 120
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  deploy:
+    name: Deploy (${{ inputs.environment_name }})
+    environment:
+      name: ${{ inputs.environment_name }}
+    runs-on: ${{ fromJSON(inputs.runner_labels_json) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify Docker availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v docker >/dev/null 2>&1 || { echo "docker not found on runner (PATH). Install Docker and ensure runner user can execute it."; exit 1; }
+          docker --version
+          docker compose version || true
+
+      - name: Docker login to GHCR
+        env:
+          CR_PAT: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$CR_PAT" | docker login ${{ inputs.image_registry }} -u ${{ github.actor }} --password-stdin
+
+      - name: Set image environment
+        run: |
+          echo "IMAGE_REGISTRY=${{ inputs.image_registry }}" >> $GITHUB_ENV
+          echo "IMAGE_REPO=${{ inputs.image_repo }}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{ inputs.image_tag }}" >> $GITHUB_ENV
+
+      - name: Pull images (with profiles)
+        env:
+          COMPOSE_PROFILES: ${{ inputs.profiles }}
+        run: docker compose pull
+
+      - name: Compose diagnostics (before up)
+        env:
+          COMPOSE_PROFILES: ${{ inputs.profiles }}
+        shell: bash
+        run: |
+          pwd
+          ls -la
+          ls -la docker-compose.yml docker-compose.yaml compose.yml compose.yaml || true
+          echo "COMPOSE_PROFILES=$COMPOSE_PROFILES"
+          env | sort | grep -E 'COMPOSE|IMAGE_|POSTGRES|DJANGO|ENV' || true
+          docker compose version || true
+          docker compose config --services || true
+          docker compose config --profiles || true
+
+      - name: Compose up deps (db + broker)
+        env:
+          COMPOSE_PROFILES: ${{ inputs.profiles }}
+        run: docker compose --profile db --profile broker up -d db redis
+
+      - name: Wait for DB health (diagnostics)
+        env:
+          COMPOSE_PROFILES: ${{ inputs.profiles }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' gestionferreteria-db 2>/dev/null || echo 'missing')
+            echo "db health/status: $status"
+            if [ "$status" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "$status" = "unhealthy" ] || [ "$status" = "exited" ] || [ "$status" = "missing" ]; then
+              echo "DB is not healthy ($status). Showing db logs..." >&2
+              docker compose logs --no-color db || true
+              docker inspect gestionferreteria-db || true
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "DB did not become healthy in time. Showing db logs..." >&2
+          docker compose logs --no-color db || true
+          docker inspect gestionferreteria-db || true
+          exit 1
+
+      - name: Fake migrations (optional)
+        if: inputs.fake_migrations != ''
+        env:
+          COMPOSE_PROFILES: ${{ inputs.profiles }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra ITEMS <<< "${{ inputs.fake_migrations }}"
+          for item in "${ITEMS[@]}"; do
+            item_trimmed=$(echo "$item" | xargs)
+            app=${item_trimmed%%:*}
+            mig=${item_trimmed##*:}
+            if [ -z "$app" ] || [ -z "$mig" ] || [ "$app" = "$mig" ]; then
+              echo "Invalid fake migration entry: '$item_trimmed' (expected app:migration)" >&2
+              exit 1
+            fi
+            echo "Faking migration: $app $mig"
+            docker compose run --rm app python src/manage.py migrate "$app" "$mig" --fake
+          done
+
+      - name: Run migrations (in-situ)
+        env:
+          COMPOSE_PROFILES: ${{ inputs.profiles }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          migrate_cmd=(docker compose run --rm app python src/manage.py migrate --fake-initial --run-syncdb --noinput)
+          set +e
+          out=$("${migrate_cmd[@]}" 2>&1)
+          code=$?
+          set -e
+          if [ $code -eq 0 ]; then
+            exit 0
+          fi
+          echo "$out" >&2
+          if ! echo "$out" | grep -Eqi 'already exists|DuplicateTable'; then
+            exit $code
+          fi
+          mig=$(echo "$out" | sed -nE 's/^\s*Applying\s+([a-zA-Z0-9_]+)\.([0-9]{4}[^[:space:]]*).*/\1 \2/p' | tail -n 1)
+          if [ -z "$mig" ]; then
+            echo "DuplicateTable detected but could not parse failing migration (no 'Applying ...' line). Aborting." >&2
+            exit $code
+          fi
+          app=$(echo "$mig" | awk '{print $1}')
+          name=$(echo "$mig" | awk '{print $2}')
+          echo "Migration failed due to DuplicateTable. Faking migration: $app $name and retrying..." >&2
+          docker compose run --rm app python src/manage.py migrate "$app" "$name" --fake
+          "${migrate_cmd[@]}"
+
+      - name: Compose up (with profiles)
+        env:
+          COMPOSE_PROFILES: ${{ inputs.profiles }}
+        run: docker compose --profile db --profile broker --profile web up -d --remove-orphans
+
+      - name: Smoke check
+        env:
+          SMOKE_URL: ${{ inputs.smoke_url }}
+          SMOKE_TIMEOUT: ${{ inputs.smoke_timeout_seconds }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          end=$((SECONDS+SMOKE_TIMEOUT))
+          until curl -fsS "$SMOKE_URL" >/dev/null; do
+            [ $SECONDS -ge $end ] && { echo "Smoke failed"; docker compose logs --no-color app || true; exit 1; }
+            sleep 3
+          done


### PR DESCRIPTION
Fix staging/prod deploy: espera explícitamente que el contenedor Postgres quede healthy (y muestra logs/inspect si queda unhealthy) antes de correr migraciones.\n\nTambién elimina el Wait duplicado en staging y endurece el step de migraciones para no ejecutar dos veces el migrate.