### PR TITLE
ci: retry dispatch of release-cicd

### DIFF
--- a/.github/workflows/standard-version.yml
+++ b/.github/workflows/standard-version.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.actions.createWorkflowDispatch({
+            const payload = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'release-cicd.yml',
@@ -95,4 +95,30 @@ jobs:
               inputs: {
                 version: '${{ steps.version.outputs.tag }}'
               }
-            })
+            }
+
+            const maxAttempts = 5
+            let lastErr
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              try {
+                await github.rest.actions.createWorkflowDispatch(payload)
+                core.info(`Workflow dispatch succeeded on attempt ${attempt}/${maxAttempts}`)
+                return
+              } catch (err) {
+                lastErr = err
+                const status = err?.status || err?.response?.status
+                const msg = err?.message || String(err)
+                core.warning(`Workflow dispatch failed (attempt ${attempt}/${maxAttempts}) status=${status}: ${msg}`)
+
+                // Retry only for transient errors (5xx / 429)
+                if (attempt === maxAttempts || !(status === 429 || (status >= 500 && status < 600))) {
+                  throw err
+                }
+
+                const delayMs = Math.min(30000, 1000 * Math.pow(2, attempt - 1))
+                core.info(`Retrying in ${delayMs}ms...`)
+                await new Promise(r => setTimeout(r, delayMs))
+              }
+            }
+
+            throw lastErr


### PR DESCRIPTION
El release falló durante el tagueo porque el dispatch a release-cicd.yml devolvió 502 (GitHub API transient).

Este PR agrega retry + exponential backoff (solo para 5xx/429) en el step 'Dispatch deploy workflow (release-cicd)' dentro de .github/workflows/standard-version.yml.