### PR TITLE
ci: cleanup docker when disk is low on runner

### DIFF
--- a/.github/workflows/reusable-compose-deploy-ghcr.yml
+++ b/.github/workflows/reusable-compose-deploy-ghcr.yml
@@ -69,6 +69,34 @@ jobs:
           echo "IMAGE_REPO=${{ inputs.image_repo }}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${{ inputs.image_tag }}" >> $GITHUB_ENV
 
+      - name: Disk space diagnostics and Docker cleanup (if low)
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "== Disk usage (df -h) =="
+          df -h || true
+          echo
+          echo "== Docker usage (docker system df) =="
+          docker system df || true
+
+          # If root filesystem has less than 10% available, attempt aggressive cleanup.
+          avail_pct=$(df -P / | awk 'NR==2{gsub(/%/,"",$5); print 100-$5}')
+          echo "Root filesystem available: ${avail_pct}%"
+          if [ -n "${avail_pct}" ] && [ "${avail_pct}" -lt 10 ]; then
+            echo "Low disk space detected (<10% available). Running Docker cleanup..." >&2
+            docker compose down -v --remove-orphans || true
+            docker container prune -f || true
+            docker image prune -af || true
+            docker builder prune -af || true
+            docker volume prune -f || true
+            echo "== After cleanup (df -h) =="
+            df -h || true
+            echo "== After cleanup (docker system df) =="
+            docker system df || true
+          else
+            echo "Disk space OK; skipping cleanup."
+          fi
+
       - name: Pull images (with profiles)
         env:
           COMPOSE_PROFILES: ${{ inputs.profiles }}


### PR DESCRIPTION
El deploy de staging falló al extraer capas de Docker con: 'no space left on device'.

Este PR agrega un paso previo al pull que:
- imprime df -h y docker system df
- si el root filesystem tiene <10% disponible, ejecuta docker prune (containers/images/build cache/volumes) y vuelve a imprimir métricas.

Afecta al reusable: .github/workflows/reusable-compose-deploy-ghcr.yml