### PR TITLE
ci: check /var free space before docker pull

### DIFF
--- a/.github/workflows/reusable-compose-deploy-ghcr.yml
+++ b/.github/workflows/reusable-compose-deploy-ghcr.yml
@@ -76,14 +76,18 @@ jobs:
           echo "== Disk usage (df -h) =="
           df -h || true
           echo
+          echo "== Disk usage (/var) =="
+          df -hT /var || true
+          echo
           echo "== Docker usage (docker system df) =="
           docker system df || true
 
-          # If root filesystem has less than 10% available, attempt aggressive cleanup.
-          avail_pct=$(df -P / | awk 'NR==2{gsub(/%/,"",$5); print 100-$5}')
-          echo "Root filesystem available: ${avail_pct}%"
-          if [ -n "${avail_pct}" ] && [ "${avail_pct}" -lt 10 ]; then
-            echo "Low disk space detected (<10% available). Running Docker cleanup..." >&2
+          # containerd/docker write mostly under /var on this runner.
+          # If /var has less than ~1200MB available, attempt aggressive cleanup.
+          avail_mb=$(df -Pm /var | awk 'NR==2{print $4}')
+          echo "/var available: ${avail_mb}MB"
+          if [ -n "${avail_mb}" ] && [ "${avail_mb}" -lt 1200 ]; then
+            echo "Low disk space detected on /var (<1200MB available). Running Docker cleanup..." >&2
             docker compose down -v --remove-orphans || true
             docker container prune -f || true
             docker image prune -af || true
@@ -91,6 +95,8 @@ jobs:
             docker volume prune -f || true
             echo "== After cleanup (df -h) =="
             df -h || true
+            echo "== After cleanup (df -hT /var) =="
+            df -hT /var || true
             echo "== After cleanup (docker system df) =="
             docker system df || true
           else


### PR DESCRIPTION
Seguimiento del PR #37: el runner tiene /var en partición separada, y el problema real de 'no space left on device' ocurre en /var/lib/containerd.

Este PR ajusta el step de limpieza/diagnóstico para:
- medir explícitamente espacio libre en /var (df -hT /var)
- disparar cleanup automático si /var < 1200MB disponibles

Commit: 4656387